### PR TITLE
test size was wrong in 'fillbatch' benchmark

### DIFF
--- a/java/benchmark/src/main/java/org/rocksdb/benchmark/DbBenchmark.java
+++ b/java/benchmark/src/main/java/org/rocksdb/benchmark/DbBenchmark.java
@@ -647,7 +647,7 @@ public class DbBenchmark {
           break;
         case "fillbatch":
           tasks.add(new WriteRandomTask(
-              currentTaskId++, randSeed_, num_ / 1000, num_, writeOpt, 1000));
+              currentTaskId++, randSeed_, num_, num_, writeOpt, 1000));
           break;
         case "fillrandom":
           tasks.add(new WriteRandomTask(


### PR DESCRIPTION
for fillbatch benchmar, the numEntries should be [num_] but not [num_ / 1000] because numEntries is just the total entries we want to test